### PR TITLE
Added Hex Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ A library for styling your terminal in Motoko!
 
 Easy to use, expressive API:
 ```motoko
-import Writer from "mo:color/Writer";
-import TextStyle from "mo:color/TextStyle";
+import Writer "mo:color/Writer";
+import TextStyle "mo:color/TextStyle";
 
 let { backgroundColor; textColor } = TextStyle;
 
@@ -32,7 +32,7 @@ Chain multiple colors on the same line:
 ...
 import Debug "mo:base/Debug";
 
-Debug.log(
+Debug.print(
   writer
     .text("It's easy being green")
     .textColor(textColor.green)

--- a/package-set.dhall
+++ b/package-set.dhall
@@ -1,4 +1,6 @@
-let upstream =
+let vessel_package_set =
       https://github.com/dfinity/vessel-package-set/releases/download/mo-0.6.21-20220215/package-set.dhall sha256:b46f30e811fe5085741be01e126629c2a55d4c3d6ebf49408fb3b4a98e37589b
 
-in  upstream
+let aviate_labs = https://github.com/aviate-labs/package-set/releases/download/v0.1.4/package-set.dhall sha256:30b7e5372284933c7394bad62ad742fec4cb09f605ce3c178d892c25a1a9722e
+
+in  vessel_package_set # aviate_labs

--- a/src/TextStyle.mo
+++ b/src/TextStyle.mo
@@ -54,31 +54,6 @@ module TextStyle {
     grey        = "38";
   };
 
-  /// Record of bright color name to ANSI SGR foreground color code
-  ///
-  /// Available Colors:
-  /// - black
-  /// - red
-  /// - green
-  /// - yellow
-  /// - blue
-  /// - purple
-  /// - lightblue
-  /// - white
-  /// - grey 
-
-  public let brightTextColor = {
-    black       = "90";
-    red         = "91";
-    green       = "92";
-    yellow      = "93";
-    blue        = "94";
-    purple      = "95";
-    lightblue   = "96";
-    white       = "97";
-    grey        = "98";
-  };
-
   public let foregroundRGBPrefix  = "38;2";
   public let backgroundRGBPrefix  = ";48;2";
   public let bold                 = ";1";

--- a/src/TextStyle.mo
+++ b/src/TextStyle.mo
@@ -2,8 +2,8 @@
 ///
 /// This module contains static text style constants which can be passed to 
 /// methods of Writer to customize text styling
-import HashMap "mo:base/HashMap";
 import Bool "mo:base/Bool";
+import HashMap "mo:base/HashMap";
 
 module TextStyle {
   /// Record of color name to ANSI SGR background color code
@@ -52,6 +52,31 @@ module TextStyle {
     lightblue   = "36";
     white       = "37";
     grey        = "38";
+  };
+
+  /// Record of bright color name to ANSI SGR foreground color code
+  ///
+  /// Available Colors:
+  /// - black
+  /// - red
+  /// - green
+  /// - yellow
+  /// - blue
+  /// - purple
+  /// - lightblue
+  /// - white
+  /// - grey 
+
+  public let brightTextColor = {
+    black       = "90";
+    red         = "91";
+    green       = "92";
+    yellow      = "93";
+    blue        = "94";
+    purple      = "95";
+    lightblue   = "96";
+    white       = "97";
+    grey        = "98";
   };
 
   public let foregroundRGBPrefix  = "38;2";

--- a/src/Writer.mo
+++ b/src/Writer.mo
@@ -4,8 +4,8 @@
 /// customization of text styling in the terminal.
 ///
 /// ```motoko
-/// import Writer from "mo:color/Writer";
-/// import TextStyle from "mo:color/TextStyle";
+/// import Writer "mo:color/Writer";
+/// import TextStyle "mo:color/TextStyle";
 ///
 /// let { backgroundColor; textColor } = TextStyle;
 ///
@@ -55,9 +55,13 @@ module {
   /// 
   /// `textColorRGB: (r: Nat8, g: Nat8, b: Nat8) -> TextStyleFunctor;`  
   /// 
+  /// `textColorHex: (hex: Text) -> TextStyleFunctor;`  
+  /// 
   /// `backgroundColor: (color: Text) -> TextStyleFunctor;`  
   /// 
   /// `backgroundColorRGB: (r: Nat8, g: Nat8, b: Nat8) -> TextStyleFunctor;`  
+  /// 
+  /// `backgroundColorHex: (hex: Text) -> TextStyleFunctor;`  
   /// 
   /// `text: (t: Text) -> TextStyleFunctor;`  
   /// 
@@ -156,7 +160,7 @@ module {
       public func textColorHex(hex: Text): TextStyleFunctor { 
         switch (hexToRGB(hex)){
           case (?(r,g,b)){ textColorRGB(r, g, b) };
-          case (_){ functor(settings) };
+          case (_){ functor(settings) }; // ignores method if hex is invalid
         };
       };
 
@@ -187,7 +191,7 @@ module {
       public func backgroundColorHex(hex: Text): TextStyleFunctor { 
         switch (hexToRGB(hex)){
           case (?(r,g,b)){ backgroundColorRGB(r, g, b) };
-          case (_){ functor(settings) };
+          case (_){ functor(settings) }; 
         };
       };
 

--- a/src/Writer.mo
+++ b/src/Writer.mo
@@ -80,8 +80,10 @@ module {
   public type TextStyleFunctor = {
     textColor: (color: Text) -> TextStyleFunctor;
     textColorRGB: (r: Nat8, g: Nat8, b: Nat8) -> TextStyleFunctor;
+    textColorHex: (hex: Text) -> TextStyleFunctor;
     backgroundColor: (color: Text) -> TextStyleFunctor;
     backgroundColorRGB: (r: Nat8, g: Nat8, b: Nat8) -> TextStyleFunctor;
+    backgroundColorHex: (hex: Text) -> TextStyleFunctor;
     text: (t: Text) -> TextStyleFunctor;
     bold: (isBold: Bool) -> TextStyleFunctor;
     italicize: (isItalicize: Bool) -> TextStyleFunctor;

--- a/src/Writer.mo
+++ b/src/Writer.mo
@@ -23,6 +23,9 @@ import TextStyle "./TextStyle";
 import Debug "mo:base/Debug";
 import Nat8 "mo:base/Nat8";
 import Bool "mo:base/Bool";
+import Result "mo:base/Result";
+
+import Hex "mo:encoding/Hex";
 
 module {
   /// All of the text styles that can be manipulated
@@ -108,6 +111,17 @@ module {
       # ";" # Nat8.toText(b); 
     };
 
+    func hexToRGB(hex: Text): ?(Nat8, Nat8, Nat8) {
+      let h = Text.trimStart(hex, #char '#');
+
+      switch (Hex.decode(h)){
+        case (#ok(bytes)){ 
+          ?(bytes[0], bytes[1], bytes[2]) 
+        };
+        case (_){ null };
+      }
+    };
+
     object {
       let settings = newSettings;
 
@@ -133,6 +147,13 @@ module {
         })
       };
 
+      public func textColorHex(hex: Text): TextStyleFunctor { 
+        switch (hexToRGB(hex)){
+          case (?(r,g,b)){ textColorRGB(r, g, b) };
+          case (_){ functor(settings) };
+        };
+      };
+
       public func backgroundColor(color: Text): TextStyleFunctor { 
         return functor({
           textColor = settings.textColor;
@@ -155,6 +176,13 @@ module {
           italicize = settings.italicize;
           underline = settings.underline;
         })
+      };
+
+      public func backgroundColorHex(hex: Text): TextStyleFunctor { 
+        switch (hexToRGB(hex)){
+          case (?(r,g,b)){ backgroundColorRGB(r, g, b) };
+          case (_){ functor(settings) };
+        };
       };
 
       public func bold(isBold: Bool): TextStyleFunctor {

--- a/src/Writer.mo
+++ b/src/Writer.mo
@@ -118,7 +118,11 @@ module {
 
       switch (Hex.decode(h)){
         case (#ok(bytes)){ 
-          ?(bytes[0], bytes[1], bytes[2]) 
+          if (bytes.size == 3){
+            ?(bytes[0], bytes[1], bytes[2]) 
+          }else{
+            null
+          };
         };
         case (_){ null };
       }

--- a/test/WriterTest.mo
+++ b/test/WriterTest.mo
@@ -139,6 +139,27 @@ run(suite("Writer composition",
         .underline(true)
         .read(),
       M.equals(T.text("\1b[38;2;20;40;60;48;2;180;200;220;1;3;4mevery rgb feature!\1b[0m"))
+    ),
+    test(
+      "hex styles are converted and applied expected",      
+      Writer()
+        .text("Adding Hex Support!")
+        .textColorHex("#14283C")
+        .backgroundColorHex("#B4C8DC")
+        .bold(true)
+        .italicize(true)
+        .underline(true)
+        .read(),
+      M.equals(T.text("\1b[38;2;20;40;60;48;2;180;200;220;1;3;4mAdding Hex Support!\1b[0m"))
+    ),
+    test(
+      "ignores hex style if it is invalid",      
+      Writer()
+        .text("wrong hex format!")
+        .textColorHex("#34D4AZ")
+        .backgroundColorHex("0x23FG34")
+        .read(),
+      M.equals(T.text("\1b[37mwrong hex format!\1b[0m"))
     )
   ]
 ));

--- a/vessel.dhall
+++ b/vessel.dhall
@@ -1,1 +1,1 @@
-{ dependencies = [ "base" ], compiler = Some "0.6.20" }
+{ dependencies = [ "base", "encoding" ], compiler = Some "0.6.20" }


### PR DESCRIPTION
Hey, I thought it would be useful if users could also enter hex values to set styles.
I imported the hex library
The reason I added this feature to the library was because I was using it in my program and had a list of preselected colors I wanted to choose from. These colors were stored as hex values and I thought it would be really inefficient and time-consuming to convert them all to rbg. I thought about other people that who might run into this issue in future so I decided to make a pr with support for hex values. 

#### Added Methods :
- `textColorHex: (hex: Text) -> TextStyleFunctor`
- `backgroundColorHex: (hex: Text) -> TextStyleFunctor`

Both functions take in a 6 letter hex string value, which can be prefixed by `#` to make 7 letters. Both functions are case insensitive so the hex values can be in lowercase or uppercase.

For a red color with hex `ff0101`, the following values are accepted
- `"#FF0101"` 
- `"#ff0101"` 
- `"FF0101"`
- `"ff0101"`

#### Example
- code
```motoko
    Writer()
        .text("- error")
        .backgroundColorHex("#FF0101")
        .print()
```

- terminal
```diff
- error
```
#### Error Handling
An issue however is that the hex entered by the user could be incorrect. And in most case the solution is to return a `Result` type that contains an error. However, I didn't want to alter the current return type of the functor so I wrote code to ignore the hex value and just return the previous settings. I don't think this is the best method of error handling as it could leave the user puzzled on what went wrong so I'm curious to know other ways error handling could be approached in the library. 